### PR TITLE
Class cast exception caused by filtered elements

### DIFF
--- a/papyrus2oml/src/main/java/io/opencaesar/papyrus2oml/converters/PackageConverter.java
+++ b/papyrus2oml/src/main/java/io/opencaesar/papyrus2oml/converters/PackageConverter.java
@@ -52,6 +52,9 @@ public class PackageConverter {
 		if (context.conversionType != ConversionType.uml_dsl || context.DSL) {
 			DescriptionBundle bundle = context.writer.createDescriptionBundle(uri, iri, SeparatorKind.HASH, prefix + calcuatedPostFix);
 			context.descriptionBundle = bundle;
+			if (context.conversionType == ConversionType.uml) {
+				context.writer.addDescriptionBundleUsage(bundle, UmlUtils.UML_BUNDLE_IRI, null);
+			}
 		}
 		if (!empty) {
 			convertPackage(package_, postFix, context);

--- a/papyrus2oml/src/main/java/io/opencaesar/papyrus2oml/converters/ProfileApplicationConverter.java
+++ b/papyrus2oml/src/main/java/io/opencaesar/papyrus2oml/converters/ProfileApplicationConverter.java
@@ -1,0 +1,49 @@
+package io.opencaesar.papyrus2oml.converters;
+
+import java.io.IOException;
+
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.uml2.uml.Profile;
+import org.eclipse.uml2.uml.ProfileApplication;
+
+import io.opencaesar.oml.Import;
+import io.opencaesar.oml.Ontology;
+import io.opencaesar.oml.VocabularyBundle;
+import io.opencaesar.oml.VocabularyBundleExtension;
+import io.opencaesar.oml.util.OmlRead;
+import io.opencaesar.papyrus2oml.ConversionType;
+import io.opencaesar.papyrus2oml.util.ResourceConverter.ConversionContext;
+import io.opencaesar.papyrus2oml.util.UmlUtils;
+
+public class ProfileApplicationConverter {
+
+	static public void convert(ProfileApplication pa, ConversionContext context) throws IOException {
+		Profile profile = pa.getAppliedProfile();
+		String iri = UmlUtils.getIRI(profile);
+		if (iri != null && !iri.isEmpty()) {
+			if (context.conversionType == ConversionType.uml_dsl) {
+				context.writer.addDescriptionBundleUsage(context.descriptionBundle, iri, null);
+			} else {
+				Resource resource = context.descriptionBundle.eResource();
+				URI uri = OmlRead.getResolvedUri(resource, URI.createURI(iri));
+				if (uri != null) {
+					Resource ontologyResource = resource.getResourceSet().getResource(uri, true);
+					if (ontologyResource != null) {
+						Ontology ontology = OmlRead.getOntology(ontologyResource);
+						if (ontology instanceof VocabularyBundle) {
+							VocabularyBundle bundle = (VocabularyBundle) ontology;
+							for (Import i : bundle.getOwnedImports()) {
+								if (i instanceof VocabularyBundleExtension) {
+									if (!i.getUri().equals(UmlUtils.UML_BUNDLE_IRI)) {
+										context.writer.addDescriptionBundleUsage(context.descriptionBundle, i.getUri(), null);
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/papyrus2oml/src/main/java/io/opencaesar/papyrus2oml/converters/UMLNamedInstanceConverter.java
+++ b/papyrus2oml/src/main/java/io/opencaesar/papyrus2oml/converters/UMLNamedInstanceConverter.java
@@ -16,7 +16,6 @@ import io.opencaesar.oml.Concept;
 import io.opencaesar.oml.Description;
 import io.opencaesar.oml.Import;
 import io.opencaesar.oml.Member;
-import io.opencaesar.oml.Ontology;
 import io.opencaesar.oml.RelationEntity;
 import io.opencaesar.oml.RelationInstance;
 import io.opencaesar.oml.Vocabulary;
@@ -27,8 +26,8 @@ import io.opencaesar.papyrus2oml.util.ResourceConverter.ConversionContext;
 import io.opencaesar.papyrus2oml.util.UmlUtils;
 
 public class UMLNamedInstanceConverter {
-	private static final String CONCEPT_POSTFIX = "_concept";
-	private static final String RELATION_POSTFIX = "_relation";
+	private static final String CONCEPT_POSTFIX = "_Concept";
+	private static final String RELATION_POSTFIX = "_Relation";
 	
 	static public void convert(Element element, ConversionContext context) throws IOException {
 		String name = UmlUtils.getName(element);
@@ -48,12 +47,10 @@ public class UMLNamedInstanceConverter {
 				if (context.conversionType == ConversionType.uml_dsl && 
 					shouldCreateRelation(element, description,rs, context)) {
 					Member relType = context.getUmlOmlElementByName(element.eClass().getName() + RELATION_POSTFIX);
-					Ontology ont = OmlRead.getOntology(relType);
 					RelationInstance instance = context.writer.addRelationInstance(description,  UmlUtils.getName(element), Collections.emptyList(),Collections.emptyList());
 					context.writer.addRelationTypeAssertion(description,OmlRead.getIri(instance), OmlRead.getIri(relType));
-					OMLUtil.addExtendsIfNeeded(description, ont.getIri(), context.writer);
 				} else {
-					createCooncept(element, context);
+					createConcept(element, context);
 				}
 			}else {
 				context.logger.warn("Did not convert: " + element);
@@ -63,7 +60,7 @@ public class UMLNamedInstanceConverter {
 		}
 	}
 
-	private static void createCooncept(Element element, ConversionContext context) {
+	private static void createConcept(Element element, ConversionContext context) {
 		Member conceptType = context.getUmlOmlElementByName(element.eClass().getName() + CONCEPT_POSTFIX);
 		UMLConceptInstanceConverter.convert(element, conceptType, context);
 	}

--- a/papyrus2oml/src/main/java/io/opencaesar/papyrus2oml/converters/UMLRelationConverter.java
+++ b/papyrus2oml/src/main/java/io/opencaesar/papyrus2oml/converters/UMLRelationConverter.java
@@ -86,11 +86,15 @@ public class UMLRelationConverter implements Runnable {
 				for (Object value : ((Collection<?>) values)) {
 					IdentifiedElement e = context.umlToOml.get(value);
 					if (e==null) {
-						// to avoid order dependency
-						NamedElement sourceELment = (NamedElement)value;
-						Member srcType = context.getUmlOmlElementByName(sourceELment.eClass().getName());
-						createInstance((RelationEntity)srcType, sourceELment, context, description);
-						e = context.umlToOml.get(value);
+						e = context.getOmlElementForIgnoredElement((Element)value, description) ;
+						if (e==null) {
+							// should happen only if the element is a relation 
+							// just in case we have a relation with source relation
+							NamedElement sourceELment = (NamedElement)value;
+							Member srcType = context.getUmlOmlElementByName(sourceELment.eClass().getName());
+							createInstance((RelationEntity)srcType, sourceELment, context, description);
+							e = context.umlToOml.get(value);
+						}
 					}
 					elements.add(OmlRead.getIri(e));
 					Ontology ont = OmlRead.getOntology(e);
@@ -98,7 +102,9 @@ public class UMLRelationConverter implements Runnable {
 				}
 			} else {
 				IdentifiedElement e = context.umlToOml.get(values);
-				assert (e != null);
+				if (e==null) {
+					e = context.getOmlElementForIgnoredElement((Element)values, description) ;
+				}
 				elements.add(OmlRead.getIri(e));
 				OMLUtil.addExtendsIfNeeded(description, OmlRead.getOntology(e).getIri(), context.writer);
 			}

--- a/papyrus2oml/src/main/java/io/opencaesar/papyrus2oml/util/DSLPackageConverter.java
+++ b/papyrus2oml/src/main/java/io/opencaesar/papyrus2oml/util/DSLPackageConverter.java
@@ -9,12 +9,14 @@ import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.uml2.uml.Element;
 import org.eclipse.uml2.uml.Package;
 import org.eclipse.uml2.uml.Profile;
+import org.eclipse.uml2.uml.ProfileApplication;
 
 import io.opencaesar.oml.util.OmlCatalog;
 import io.opencaesar.oml.util.OmlWriter;
 import io.opencaesar.papyrus2oml.ConversionType;
 import io.opencaesar.papyrus2oml.converters.NamedInstanceConverter;
 import io.opencaesar.papyrus2oml.converters.PackageConverter;
+import io.opencaesar.papyrus2oml.converters.ProfileApplicationConverter;
 
 public class DSLPackageConverter extends ResourceConverter {
 	
@@ -54,6 +56,8 @@ public class DSLPackageConverter extends ResourceConverter {
 			PackageConverter.convertRootPackage(context.rootPackage,context.postFix, context);
 		} else if (eObject instanceof Package) {
 			PackageConverter.convertPackage((Package) eObject,context.postFix, context);
+		} else if (eObject instanceof ProfileApplication) {
+			ProfileApplicationConverter.convert((ProfileApplication) eObject, context);
 		} else if (eObject instanceof Element) {
 			NamedInstanceConverter.convert((Element) eObject, context);
 		} else {

--- a/papyrus2oml/src/main/java/io/opencaesar/papyrus2oml/util/ResourceConverter.java
+++ b/papyrus2oml/src/main/java/io/opencaesar/papyrus2oml/util/ResourceConverter.java
@@ -80,7 +80,7 @@ public abstract class ResourceConverter {
 		private static String getIgnoredElementIRI(Element element, ConversionContext context) {
 			Package pkg = element.getNearestPackage();
 			// try load the elements ontology directly from context 
-			var bundleResource = context.descriptionBundle.eResource();
+			var bundleResource = context.umlVoc.eResource();
 			var ontologyUri = OmlRead.getResolvedUri(bundleResource, URI.createURI(pkg.getURI()));
 			Resource ontologyResource = bundleResource.getResourceSet().getResource(ontologyUri, true);
 			Ontology ontology = OmlRead.getOntology(ontologyResource);

--- a/papyrus2oml/src/main/java/io/opencaesar/papyrus2oml/util/UmlUtils.java
+++ b/papyrus2oml/src/main/java/io/opencaesar/papyrus2oml/util/UmlUtils.java
@@ -25,6 +25,7 @@ public class UmlUtils {
 
 	public static final String UML_IRI = "http://www.eclipse.org/uml2/5.0.0/UML";
 	public static final String UML_NS = UML_IRI+"#";
+	public static final String UML_BUNDLE_IRI = UML_IRI+"-Bundle";
 	
 	static public String getIri(Property property) {
 		EAnnotation annotation = property.getEAnnotation(OMLIRI);


### PR DESCRIPTION
* Use the new getOmlElementForIgnoredElement to deal with filtered items
* Add some safeguard to handle the potential use case where a relation source is another relation 